### PR TITLE
Fix highlight.js theme backgrounds

### DIFF
--- a/src/__tests__/fixtures/output.html
+++ b/src/__tests__/fixtures/output.html
@@ -1,9 +1,9 @@
 <h1>CSS Example</h1>
-<pre><code class="language-css"><span class="hljs-tag">h1</span> <span class="hljs-rules">{
+<pre><code class="hljs"><span class="hljs-tag">h1</span> <span class="hljs-rules">{
     <span class="hljs-rule"><span class="hljs-attribute">color</span>:<span class="hljs-value"> red
 }</span></span></span></code></pre>
 <h1>JS Example</h1>
-<pre><code class="language-js"><span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params"></span>) </span>{}</code></pre>
+<pre><code class="hljs"><span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params"></span>) </span>{}</code></pre>
 <h1>No highlighting</h1>
 <pre><code>$ cat ~/.bashrc
 </code></pre>

--- a/src/__tests__/fixtures/output.html
+++ b/src/__tests__/fixtures/output.html
@@ -1,9 +1,9 @@
 <h1>CSS Example</h1>
-<pre><code class="hljs"><span class="hljs-tag">h1</span> <span class="hljs-rules">{
+<pre><code class="hljs language-css"><span class="hljs-tag">h1</span> <span class="hljs-rules">{
     <span class="hljs-rule"><span class="hljs-attribute">color</span>:<span class="hljs-value"> red
 }</span></span></span></code></pre>
 <h1>JS Example</h1>
-<pre><code class="hljs"><span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params"></span>) </span>{}</code></pre>
+<pre><code class="hljs language-js"><span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params"></span>) </span>{}</code></pre>
 <h1>No highlighting</h1>
 <pre><code>$ cat ~/.bashrc
 </code></pre>

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,9 @@ export default function attacher () {
         }
 
         data.htmlContent = hljs.highlightAuto(node.value, [node.lang]).value;
+        data.htmlAttributes = {
+            class: 'hljs'
+        };
     }
 
     return ast => visit(ast, 'code', visitor);

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export default function attacher () {
 
         data.htmlContent = hljs.highlightAuto(node.value, [node.lang]).value;
         data.htmlAttributes = {
-            class: 'hljs'
+            class: 'hljs language-' + node.lang
         };
     }
 


### PR DESCRIPTION
For highlight.js themes to work properly, `hljs` className should be set on the target container:

``` html
<pre><code class="hljs">
<span class="hljs-keyword">var</span> mdast = <span class="hljs-built_in">require</span>(<span class="hljs-string">'mdast'</span>);
<!-- the rest of hljs-compiled html -->
</code></pre>
```

Check out [highlight.js styles directory](https://github.com/isagalaev/highlight.js/tree/master/src/styles) to see how it's used, but the bottomline is some themes (especially dark ones) become unreadable if background is left behind.

---

![backgrounds working](https://cloud.githubusercontent.com/assets/4472489/9765555/8666ba20-571d-11e5-9ab2-24dfa2d648f4.png)
