### PR TITLE
Preserve existing htmlAttributes on nodes

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -15,3 +15,23 @@ test('should highlight css & js', t => {
     let result = mdast.use([ html, hljs ]).process(base('input.md'));
     t.equal(result, base('output.html'));
 });
+
+test('should not modify existing htmlAttributes and classes', t => {
+    t.plan(2);
+
+    let ast = mdast.parse('```lang\n```', { position: false });
+    ast = mdast()
+        .use(() => ast => {
+            ast.children[0].data = {
+                htmlAttributes: {
+                    'data-foo': 'bar',
+                    class: 'quux'
+                }
+            };
+        })
+        .use(hljs)
+        .run(ast);
+
+    t.equal(ast.children[0].data.htmlAttributes['data-foo'], 'bar');
+    t.true(ast.children[0].data.htmlAttributes.class.indexOf('quux') >= 0);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,12 @@ export default function attacher () {
         }
 
         data.htmlContent = hljs.highlightAuto(node.value, [node.lang]).value;
-        data.htmlAttributes = {
-            class: 'hljs language-' + node.lang
-        };
+        data.htmlAttributes = data.htmlAttributes || {};
+        data.htmlAttributes.class = [
+            data.htmlAttributes.class,
+            'hljs',
+            'language-' + node.lang
+        ].filter(Boolean).join(' ');
     }
 
     return ast => visit(ast, 'code', visitor);


### PR DESCRIPTION
This patch makes this plugin more composable with other mdast plugins by checking for existing `htmlAttributes` and class names and preserving them.
