### PR TITLE
Allow to define prefix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,10 @@ that *are* in this list.
 If this option is defined (`Array`), this plugin will only highlight languages
 that *are not* in this list.
 
+###### `options.prefix`
+
+If this option is defined (`string`), this plugin will use this prefix for classes instead of `hljs-`.
+
 ## Security
 
 Use of `remark-highlight.js` *should* be safe to use as `lowlight` *should* be

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,8 @@ that *are not* in this list.
 
 ###### `options.prefix`
 
-If this option is defined (`string`), this plugin will use this prefix for classes instead of `hljs-`.
+If this option is defined (`string`), this plugin will use this prefix
+for classes instead of `hljs-`.
 
 ## Security
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -51,6 +51,17 @@ test('should not highlight when the language is not specified (exclude)', t => {
   )
 })
 
+test('should allow to change prefix', t => {
+  t.truthy(
+    remark()
+      .use(html)
+      .use(hljs, {prefix: 'code_'})
+      .processSync('# Hello!\n\n```css\nh1{}\n```')
+      .toString()
+      .includes('class="code_selector-tag')
+  )
+})
+
 test('should not modify existing hProperties and classes', t => {
   const tree = remark()
     .use(() => tree => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import low from 'lowlight'
 import visit from 'unist-util-visit'
 
-export default function attacher({include, exclude} = {}) {
+export default function attacher({include, exclude, prefix} = {}) {
   return ast => visit(ast, 'code', visitor)
 
   function visitor(node) {
@@ -24,7 +24,7 @@ export default function attacher({include, exclude} = {}) {
       data.hProperties = {}
     }
 
-    data.hChildren = low.highlight(lang, node.value).value
+    data.hChildren = low.highlight(lang, node.value, {prefix}).value
     data.hProperties.className = [
       'hljs',
       ...(data.hProperties.className || []),


### PR DESCRIPTION
I need to change the prefix to keep BEM naming consistency in my project, so in this PR I added `prefix` option, which is already supported by `lowlight`.