### PR TITLE
Add a way to register custom languages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,16 @@
 import low from 'lowlight'
 import visit from 'unist-util-visit'
 
-export default function attacher({include, exclude, prefix} = {}) {
+export default function attacher({include, exclude, prefix, languages} = {}) {
+
+  // register custom languages
+  if (languages) {
+    // eslint-disable-next-line guard-for-in
+    for (let name in languages) {
+     low.registerLanguage(name, languages[name])
+    }
+  }
+
   return (ast) => visit(ast, 'code', visitor)
 
   function visitor(node) {


### PR DESCRIPTION
Added a new prop to allow people to register custom language plugins which are not supported by default.